### PR TITLE
Require TS 5.7 and update target to ES2024

### DIFF
--- a/fixtures/dom-iterable.tsx
+++ b/fixtures/dom-iterable.tsx
@@ -1,0 +1,6 @@
+const formData = new FormData()
+formData.set('name', 'Aliza')
+
+for (const [key, value] of formData) {
+  console.log(key, value)
+}

--- a/fixtures/es2024.tsx
+++ b/fixtures/es2024.tsx
@@ -1,0 +1,14 @@
+interface Item {
+  name: string
+  type: 'fruit' | 'vegetable'
+}
+
+const produce: Item[] = [
+  {name: 'apple', type: 'fruit'},
+  {name: 'banana', type: 'fruit'},
+  {name: 'carrot', type: 'vegetable'},
+]
+
+const result = Map.groupBy(produce, (item) => item.type)
+
+console.log(result.get('fruit'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@kensho-technologies/prettier-config": "^3.0.0",
         "@types/react": "^18.3.12",
-        "prettier": "^3.3.3",
+        "prettier": "^3.4.1",
         "react": "^18.3.1"
       },
       "engines": {
@@ -19,7 +19,7 @@
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": "^5.7.0"
       }
     },
     "node_modules/@kensho-technologies/prettier-config": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "license": "Apache-2.0",
   "prettier": "@kensho-technologies/prettier-config",
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.7.0"
   },
   "devDependencies": {
     "@kensho-technologies/prettier-config": "^3.0.0",
     "@types/react": "^18.3.12",
-    "prettier": "^3.3.3",
+    "prettier": "^3.4.1",
     "react": "^18.3.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,13 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ES2022",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "strict": true,
-    "target": "ES2022",
+    "target": "ES2024",
     "tsBuildInfoFile": ".tsbuildinfo"
   }
 }


### PR DESCRIPTION
This also adds `lib` to the config for two reasons:
1. `target` is supposed to include corresponding `lib` definitions but this isn't the case for ES2024 because of a bug in TS 5.7: https://github.com/microsoft/TypeScript/issues/60621
2. `DOM.Iterable` is excluded by default but it makes sense to include. See [the source](https://github.com/microsoft/TypeScript/blob/9fe6c3661cd89952d9556ecb14ef366b44076064/src/lib/dom.iterable.d.ts) and [this discussion](https://stackoverflow.com/questions/71510368/why-are-dom-and-dom-iterable-separate).