### PR TITLE
Downgrade target to ES2023

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "strict": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "tsBuildInfoFile": ".tsbuildinfo"
   }
 }


### PR DESCRIPTION
esbuild (used internally by Vite) has trouble parsing a tsconfig when `target` is set to `ES2024`. I've PRed a fix (https://github.com/evanw/esbuild/pull/3990) but not sure if it will be merged/released.

`target` affects two things: the `lib` defaults (which we've already overridden in https://github.com/kensho-technologies/tsconfig/pull/12) and the transpiler output. We generally don't use the TS transpiler anyway so let's just downgrade `target` to avoid the Vite issue.