### PR TITLE
Enable `skipLibCheck`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "ESNext",
     "tsBuildInfoFile": ".tsbuildinfo"


### PR DESCRIPTION
One of the most common overrides; let's enable this by default.