### PR TITLE
Remove build info filename override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /node_modules/
-/.tsbuildinfo
+*.tsbuildinfo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
-    "target": "ESNext",
-    "tsBuildInfoFile": ".tsbuildinfo"
+    "target": "ESNext"
   }
 }


### PR DESCRIPTION
This was occasionally causing problems when multiple tsconfigs were present in a repo.